### PR TITLE
ホーム画面にTodo一覧画面の追加

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -11,9 +11,42 @@ a.home {
 }
 
 main {
-    display: flex;
-    justify-content: center;
-    align-items: center; 
+    text-align: center;
+    width: 50%;
+    margin: 5% 25% 3% 25%;
+}
+
+.page-title {
+    text-align: center;
+}
+
+ol {
+    border-width: 1px;
+    border-style: solid;
+}
+
+.list {
+    list-style-position: inside;
+    color: gray;
+}
+
+li {
+    background-color: orange;
+    margin: 10% 5% 10% 15%;
+    width: 60%;
+}
+
+.list span {
+    color: white;
+}
+
+.pagination {
+    width: 30px;
+    height: 25px;
+    border-radius: 50%;
+    background-color: orange;
+    color: white;
+    margin: 0 45%;
 }
 
 a.login {

--- a/css/index.css
+++ b/css/index.css
@@ -1,12 +1,27 @@
 header { 
     background-color: orange;
+    display: flex;
+    justify-content: space-around;
+    align-items: center; 
 }
 
 a.home {
-    width: 70%;
+    width: 50%;
     display: inline-block;
     margin-left: 10%;
     font-size: 200%;
+    color: white;
+}
+
+a.login {
+    width:10%;
+    font-size: 150%;
+    color: white;
+}
+
+a.sign-up {
+    width:20%;
+    font-size: 150%;
     color: white;
 }
 
@@ -56,12 +71,6 @@ li {
     background-color: orange;
     color: white;
     margin: 0 45%;
-}
-
-a.login {
-    width:10px;
-    font-size: 150%;
-    color: white;
 }
 
 footer { 

--- a/css/index.css
+++ b/css/index.css
@@ -40,6 +40,15 @@ li {
     color: white;
 }
 
+.list span a {
+    text-decoration: none;
+    color: white;
+}
+
+.list span a:hover {
+    color: #FFBF11;
+}
+
 .pagination {
     width: 30px;
     height: 25px;

--- a/html/index.html
+++ b/html/index.html
@@ -27,7 +27,7 @@
         </main>
 
         <footer>
-            <p><small>&copy; 2024 todoカンリ</small></p>
+            <p><small>&copy; 2024 Todoカンリ</small></p>
         </footer>
     </body>
 </html>

--- a/html/index.html
+++ b/html/index.html
@@ -18,7 +18,7 @@
         <main>
             <h1 class="page-title">todo一覧</h1>
             <ol class="list" type="1">
-                <li><span>タイトル  &emsp; 詳細確認</span></li>
+                <li><span>タイトル  &emsp;<a href="details.html">詳細確認</a></span></li>
                 <li><span>タイトル  &emsp; 詳細確認</span></li>
                 <li><span>タイトル  &emsp; 詳細確認</span></li>
                 <li><span>タイトル  &emsp; 詳細確認</span></li>

--- a/html/index.html
+++ b/html/index.html
@@ -9,14 +9,13 @@
 
     <body>
         <header>
-            <a class="home" href="index.html" style="text-decoration:none;">todoカンリ</a>
-                
+            <a class="home" href="index.html" style="text-decoration:none;">Todoカンリ</a>
             <a class="login" href="login.html" style="text-decoration:none;">ログイン</a>
-            </div>
+            <a class="sign-up" href="sign-up.html" style="text-decoration:none;">会員登録</a>
         </header>
 
         <main>
-            <h1 class="page-title">todo一覧</h1>
+            <h1 class="page-title">Todo一覧</h1>
             <ol class="list" type="1">
                 <li><span>タイトル  &emsp;<a href="details.html">詳細確認</a></span></li>
                 <li><span>タイトル  &emsp; 詳細確認</span></li>

--- a/html/index.html
+++ b/html/index.html
@@ -16,7 +16,15 @@
         </header>
 
         <main>
-            <h1>このアプリはtodoをカンリすることができます。</h1>
+            <h1 class="page-title">todo一覧</h1>
+            <ol class="list" type="1">
+                <li><span>タイトル  &emsp; 詳細確認</span></li>
+                <li><span>タイトル  &emsp; 詳細確認</span></li>
+                <li><span>タイトル  &emsp; 詳細確認</span></li>
+                <li><span>タイトル  &emsp; 詳細確認</span></li>
+                <li><span>タイトル  &emsp; 詳細確認</span></li>
+                <div class="pagination">1</div>
+            </ol>
         </main>
 
         <footer>


### PR DESCRIPTION
# 実装概要
ホーム画面に自作したTodoリストの一覧を表示させました
一覧は詳細確認画面を参考にしました
フッターを大文字に変更しました
会員登録ボタンを作成して会員登録ができるようにしました
# 実装詳細
TodoリストはTodo管理画面を参考にしました
会員登録はaタグで新規登録画面へ移動できるようにしました
ol,li,spanタグを使用してリストを表示するようにしました
footerタグ内のアプリ名を大文字に変更しました
# 開発していてわからなかった部分
なし
# テスト項目と確認したことについて
- 仕様の確認
- Todoカンリ、ログイン、会員登録のボタンでそれぞれのページに移動できるのか
- 背景色の確認
- 一覧画面を中央に表示している
- 詳細確認画面に移動できる
- フッターのフォントのカラー
- 背景色の確認
- フッターの中央揃え